### PR TITLE
Fix typo in the name of a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ USAGE: Set multi-cursor and call bellow commands.
 
 ![Insert bitfield demo](./images/bit.gif)
 
-### _Command_: Insert charcter to multiple rows :capital_abcd:
+### _Command_: Insert character to multiple rows :capital_abcd:
 
-![Insert charcter demo](./images/char.gif)
+![Insert character demo](./images/char.gif)
 
 ## Extension Settings
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       },
       {
         "command": "extension.insCharMulrows",
-        "title": "Insert charcter to multiple rows"
+        "title": "Insert character to multiple rows"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,7 +184,7 @@ export function activate(context: ExtensionContext) {
     );
 
     /*------------------------------------------------------------------------------------------*/
-    /*  Insert charcter to multiple rows                                                        */
+    /*  Insert character to multiple rows                                                        */
     /*------------------------------------------------------------------------------------------*/
     const insCharMulrowsCmd = commands.registerCommand(
         'extension.insCharMulrows',


### PR DESCRIPTION
I think a typo sneaked his way up to the name of the commands in the extension. :sweat_smile: 
Now works better for users who are looking to insert sequential characters in their code.